### PR TITLE
ER-51: lensPg replacement for profiles sitemap

### DIFF
--- a/apps/api/src/helpers/constants.ts
+++ b/apps/api/src/helpers/constants.ts
@@ -39,4 +39,4 @@ export const CACHE_AGE_INDEFINITE_ON_DISK =
 
 // Tests
 export const TEST_URL = 'http://127.0.0.1:4784';
-export const SITEMAP_BATCH_SIZE = 50000;
+export const SITEMAP_BATCH_SIZE = 50; // Lens API limits results to a maximum of 50

--- a/apps/api/src/routes/badges/isGoodProfile.ts
+++ b/apps/api/src/routes/badges/isGoodProfile.ts
@@ -65,12 +65,12 @@ export const get: Handler = async (req, res) => {
       ? getAddress(address)
       : await fetchAddressFromProfileId(id!);
 
-    const viemclient = createPublicClient({
+    const viemClient = createPublicClient({
       chain: IS_MAINNET ? polygon : polygonAmoy,
       transport: getRpc({ mainnet: IS_MAINNET })
     });
 
-    const data = await viemclient.readContract({
+    const data = await viemClient.readContract({
       abi: GoodLensSignup,
       address: GOOD_LENS_SIGNUP,
       args: [formattedAddress],

--- a/apps/api/src/routes/lens/internal/stats/goodRevenue.ts
+++ b/apps/api/src/routes/lens/internal/stats/goodRevenue.ts
@@ -74,12 +74,12 @@ export const get: Handler = async (req, res) => {
   }
 
   try {
-    const viemclient = createPublicClient({
+    const viemClient = createPublicClient({
       chain: IS_MAINNET ? polygon : polygonAmoy,
       transport: getRpc({ mainnet: IS_MAINNET })
     });
 
-    const signupCount = await viemclient.readContract({
+    const signupCount = await viemClient.readContract({
       abi: GoodLensSignup,
       address: GOOD_LENS_SIGNUP,
       args: [],


### PR DESCRIPTION
## What does this PR do?

Remove usage of lens pg database in the profiles sitemap

## Related issues

Fixes ER-51

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

Change profiles sitemap to query Lens API and not Lens PG database