### PR TITLE
ER-45 lensPG replacement for rate endpoint

### DIFF
--- a/apps/api/src/routes/lens/rate.ts
+++ b/apps/api/src/routes/lens/rate.ts
@@ -1,34 +1,17 @@
 import type { Handler } from 'express';
 
 import logger from '@good/helpers/logger';
-import lensPg from 'src/db/lensPg';
+import axios from 'axios';
 import catchedError from 'src/helpers/catchedError';
 import { SWR_CACHE_AGE_10_SECS_30_DAYS } from 'src/helpers/constants';
 
-// TODO: add tests
 export const get: Handler = async (req, res) => {
   try {
-    const response = await lensPg.query(`
-      SELECT ec.name AS name,
-        ec.symbol AS symbol,
-        ec.decimals AS decimals,
-        ec.currency AS address,
-        fc.price AS fiat
-      FROM fiat.conversion AS fc
-      JOIN enabled.currency AS ec ON fc.currency = ec.currency
-      WHERE fc.fiatsymbol = 'usd';
-    `);
+    const response = await axios.get('https://api.hey.xyz/lens/rate');
 
-    const result = response.map((row: any) => ({
-      address: row.address.toLowerCase(),
-      decimals: row.decimals,
-      fiat: Number(row.fiat),
-      name: row.name,
-      symbol: row.symbol
-    }));
+    const { result } = response.data;
 
-    logger.info('Lens: Fetched USD conversion rates');
-
+    logger.info('Lens: Fetched cryptocurrency conversion rates from hey.xyz');
     return res
       .status(200)
       .setHeader('Cache-Control', SWR_CACHE_AGE_10_SECS_30_DAYS)


### PR DESCRIPTION
## What does this PR do?
Instead of using lensPG endpoint it uses hey endpoint to find conversion rates

## Related issues
Fixed ER-45

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes
Changed the lensPG endpoint to the hey endpoint and handled the data correctly
