### PR TITLE
ER-101: Missing separation between setup profile card and search bar

### DIFF
--- a/apps/web/src/components/Shared/Navbar/Search/index.tsx
+++ b/apps/web/src/components/Shared/Navbar/Search/index.tsx
@@ -80,7 +80,7 @@ const Search: FC<SearchProps> = ({ placeholder = 'Search…' }) => {
   }, [debouncedSearchText]);
 
   return (
-    <div className="w-full">
+    <div className="mb-4 w-full">
       <form onSubmit={handleKeyDown}>
         <Input
           className="px-3 py-2 text-sm"


### PR DESCRIPTION
## What does this PR do?

Add separation between setup profile card and search bar

## Related issues

Fixes ER-101

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

Add separation between setup profile card and search bar
