### PR TITLE
Fix tab hover colour on light mode

### DIFF
--- a/packages/ui/src/TabButton.tsx
+++ b/packages/ui/src/TabButton.tsx
@@ -36,7 +36,7 @@ const TabButton: FC<TabButtonProps> = ({
         aria-label={name}
         className={cn(
           'flex items-center justify-center space-x-2 text-sm sm:px-3 sm:py-1.5',
-          'h-full w-full rounded-full hover:bg-gray-800',
+          'h-full w-full rounded-full hover:bg-gray-300 dark:hover:bg-gray-800',
           {
             'font-bold text-black dark:text-white': active,
             'text-gray-500': !active


### PR DESCRIPTION
## What does this PR do?

## Related issues

Fixes #ER-121

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

Changes light mode hover background colour for feed type buttons
