### PR TITLE
ER-105: Fix "More" navbar menu being cut off

### DIFF
--- a/apps/web/src/components/Shared/Navbar/MoreNavItems.tsx
+++ b/apps/web/src/components/Shared/Navbar/MoreNavItems.tsx
@@ -42,7 +42,7 @@ const MoreNavItems: FC = () => {
           </MenuButton>
           <MenuTransition>
             <MenuItems
-              className="absolute bottom-0 left-0 mb-2 rounded-xl border bg-white shadow-sm focus:outline-none dark:border-gray-700 dark:bg-gray-900"
+              className="absolute bottom-0 left-0 mb-2 max-h-[25vh] overflow-y-auto rounded-xl border bg-white shadow-sm focus:outline-none dark:border-gray-700 dark:bg-gray-900"
               static
             >
               {currentProfile ? (


### PR DESCRIPTION
## What does this PR do?

Fix "More" navbar menu being cut off

## Related issues

Fixes ER-105

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

Makes submenu scrollable when too tall