### PR TITLE
ER-103: Fix input elements on profile settings page extending out of container

### DIFF
--- a/apps/web/src/components/Settings/Profile/Profile.tsx
+++ b/apps/web/src/components/Settings/Profile/Profile.tsx
@@ -437,7 +437,7 @@ const ProfileSettingsForm: FC = () => {
               <div>
                 <Image
                   alt="Cover picture crop preview"
-                  className="h-[175px] w-[675px] rounded-lg object-cover"
+                  className="h-[175px] w-full rounded-lg object-cover"
                   onError={({ currentTarget }) => {
                     currentTarget.src =
                       sanitizeDStorageUrl(coverPictureIpfsUrl);


### PR DESCRIPTION
## What does this PR do?

Fix input elements on profile settings page extending out of container

## Related issues

Fixes ER-103

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes
