### PR TITLE
Squared off all borders on mobile view

### DIFF
--- a/apps/web/src/components/Shared/Navbar/index.tsx
+++ b/apps/web/src/components/Shared/Navbar/index.tsx
@@ -181,7 +181,7 @@ const Navbar: FC = () => {
   };
 
   return (
-    <header className="sticky top-0 z-10 mt-8 min-h-fit min-w-fit rounded-xl border bg-white md:w-fit dark:border-gray-700 dark:bg-black">
+    <header className="sticky top-0 z-10 mt-8 min-h-fit min-w-fit border-b border-t bg-white md:w-fit md:rounded-xl md:border dark:border-gray-700 dark:bg-black">
       <SiteStatus />
       {staffMode ? <StaffBar /> : null}
       <NavbarContainer className="container mx-auto w-full pb-2 pt-2 lg:pb-6 lg:pt-6">

--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -20,10 +20,10 @@ export const Card: FC<CardProps> = ({
   return (
     <Tag
       className={cn(
-        forceRounded
-          ? 'rounded-xl'
-          : 'rounded-none border-x-0 sm:rounded-xl sm:border-x',
-        'border bg-white dark:border-gray-700 dark:bg-black',
+        'rounded-none border border-x-0 bg-white dark:border-gray-700 dark:bg-black',
+        {
+          'sm:rounded-xl sm:border-x': forceRounded
+        },
         className
       )}
       onClick={onClick}


### PR DESCRIPTION
## What does this PR do?
Squares off Borders in Mobile View
## Related issues
ER-168

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes
Changed the top navbar and empty card so that the borders are no longer rounded.