### PR TITLE
ER-169

### DIFF
--- a/apps/web/src/components/Explore/index.tsx
+++ b/apps/web/src/components/Explore/index.tsx
@@ -52,7 +52,7 @@ const Explore: NextPage = () => {
           <div className="mb-5">
             <Search />
           </div>
-          <TabList className="divider space-x-8">
+          <TabList className="divider flex space-x-2 overflow-x-auto whitespace-nowrap">
             {tabs.map((tab, index) => (
               <Tab
                 className={({ selected }) =>


### PR DESCRIPTION
## What does this PR do?
Make the tabs on explore page responsive
## Related issues
ER-169

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes
Made it so that the tabs are always on one line no matter the screen size. 